### PR TITLE
Fixed build, fixed bug: expose before produce in VirtualThing

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "wot-typescript-definitions": "0.7.1-SNAPSHOT.1"
   },
   "scripts": {
-    "preinstall": "npm run pre:windows",
+    "preinstall": "npm run pre:default",
     "pre:windows": "rmdir /s /q thingweb.node-wot & rmdir /s /q node_modules & del /s /q /f package-lock.json",
     "pre:default": "rm -rf thingweb.node-wot && rm -rf node_modules && rm -rf package-lock.json",
     "start": "node dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,19 +363,25 @@ const startVirtualization = (config: ConfigFile, things: WoT.ThingDescription[],
         things.forEach((td: WoT.ThingDescription) => {
             if (config.things.hasOwnProperty(td.id)) {
                 if(config.things[td.id].nInstance === 1){
-                    new VirtualThing(td, thingFactory, config.things[td.id]).expose();
+                    new VirtualThing(td, thingFactory, config.things[td.id])
+                        .produce().then(vt => vt.expose());
                     console.info(`Exposing ${td.title}`);
                 }else{
                     var i;
                     for(i = 0; i<config.things[td.id].nInstance; i++){
-                        new VirtualThing({...td, title: td.title + (i+1), id: td.id + ':n-' + (i+1)}, thingFactory, config.things[td.id]).expose();
+                        new VirtualThing({...td, title: td.title + (i+1), id: td.id + ':n-' + (i+1)},
+                                thingFactory,
+                                config.things[td.id])
+                            .produce().then(vt => vt.expose());
                         console.info(`Exposing instance ${i+1} of ${td.title}`);
                     }
                 }
             } else {
-                let vt = new VirtualThing(td, thingFactory);
-                console.info("Exposing " + td.title);
-                vt.expose();
+                new VirtualThing(td, thingFactory)
+                    .produce().then(vt => {
+                        vt.expose();
+                        console.info("Exposing " + td.title);
+                    });
             }
         });
         twins.forEach((td) => {

--- a/src/digital-twin.ts
+++ b/src/digital-twin.ts
@@ -26,6 +26,7 @@ export class DigitalTwin {
             virtualTD.title = "Virtual-Thing" + Math.floor(Math.random() * 1000);
             virtualTD.id = "de:tum:ei:esi:fp:virt" + Math.floor(Math.random() * 1000);
             this.virtualThing = new VirtualThing(virtualTD, factory, config);
+            this.virtualThing.produce();
 
             // Initialise custom handlers and last read values objects
             this.customHandlers = {};

--- a/src/server-pool.ts
+++ b/src/server-pool.ts
@@ -147,7 +147,7 @@ const initThings = async (tdPath: string, thingFactory: WoT.WoT, servNum: number
                 {
                     eventIntervals: thingConf.eventIntervals
                 }
-            ).expose()
+            ).produce().then(vt => vt.expose());
             var endTime = new Date();
             log(String(endTime.getTime() - startTime.getTime()));
             var curThingNb = servNum * i

--- a/src/virtual-thing.ts
+++ b/src/virtual-thing.ts
@@ -15,7 +15,9 @@ ajv.addSchema(schema, 'td');
 export class VirtualThing {
     public readonly config: any;
     public readonly thingDescription: WoT.ThingDescription;
-    public thing: WoT.ExposedThing;
+    public thing: WoT.ExposedThing = undefined;
+
+    private factory: WoT.WoT;
     
     /**
      * Create a virtual thing
@@ -24,21 +26,31 @@ export class VirtualThing {
      * @param config - An optional config object.
      */
     public constructor(td: WoT.ThingDescription, factory: WoT.WoT, config?: VirtualThingConfig) {
-
+        
         this.config = config;
+        this.factory = factory;
 
         // Convert TD to an object and validate it.
         this.thingDescription = td;
-        this.validateThingDescription();
+        this.validateThingDescription();        
+    }
 
-        // Generate an ExposedThing
-        factory.produce(this.thingDescription).then(thing =>{
-            this.thing = thing;
-
-            // Add property and action handlers
-            this.addPropertyHandlers();
-            this.addActionHandlers();
-            this.generateEvents();
+    /** Produce thing from TD */
+    public produce() : Promise<VirtualThing> {
+        return new Promise((resolve) => {
+            if(this.thing == undefined){
+                // Generate an ExposedThing
+                this.factory.produce(this.thingDescription).then(thing =>{
+                    this.thing = thing;
+                    // Add property and action handlers
+                    this.addPropertyHandlers();
+                    this.addActionHandlers();
+                    this.generateEvents();
+                    resolve(this);
+                });
+            }else{
+                resolve(this);
+            }            
         });
     }
 


### PR DESCRIPTION
- In package.json: changed `scripts/preinstall` from `npm run pre:windows` to `npm run pre:default` to fix building on Linux
- Fixed bug: in `VirtualThing` class, Thing could be exposed by expose() before being produced in the class constructor. Added `function produce(): Promise` such that produce() and expose() can be chained. Now, before calling expose(), produce() has to be called and Thing has to be produced completely.
